### PR TITLE
Update SDK dependency in examples

### DIFF
--- a/examples/crewai/marketing_posts/package.json
+++ b/examples/crewai/marketing_posts/package.json
@@ -12,7 +12,7 @@
     "serve:sse": "tsx src/server.ts sse"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.4",
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "@types/js-yaml": "^4.0.9",
     "dotenv": "^16.4.7",
     "js-yaml": "^4.1.0",

--- a/examples/langgraph/reflection_agent/package.json
+++ b/examples/langgraph/reflection_agent/package.json
@@ -16,7 +16,7 @@
     "@langchain/core": "^0.3.28",
     "@langchain/langgraph": "^0.2.73",
     "@langchain/openai": "^0.3.20",
-    "@modelcontextprotocol/sdk": "^1.0.4",
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "dotenv": "^16.4.7",
     "zod": "^3.23.8"
   },

--- a/examples/langgraph/self_discover_agent/package.json
+++ b/examples/langgraph/self_discover_agent/package.json
@@ -16,7 +16,7 @@
     "@langchain/core": "^0.3.28",
     "@langchain/langgraph": "^0.2.73",
     "@langchain/openai": "^0.3.20",
-    "@modelcontextprotocol/sdk": "^1.0.4",
+    "@modelcontextprotocol/sdk": "^1.12.0",
     "dotenv": "^16.4.7",
     "zod": "^3.23.8"
   },


### PR DESCRIPTION
## Summary
- update `@modelcontextprotocol/sdk` to `^1.12.0` in example packages

## Testing
- `npm install`
- `npm run build`
- `npm run build` in `examples/crewai/marketing_posts`
- `npm run build` in `examples/openai/multi-agent`
- `npm run build` in `examples/pydantic/weather-app`
- `npm install` *(fails: ETARGET No matching version found for @langchain/openai@^0.3.20)*
- `npm install` *(fails: ETARGET No matching version found for @llamaindex/openai@^0.7.0)*
- `npm run build` *(fails to find modules from @modelcontextprotocol/sdk)*

------
https://chatgpt.com/codex/tasks/task_e_6855cf2b45188325a5b5d515a5fcd2e3