### PR TITLE
Fix schema handling and templates for TS adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ automcp-ts generate-adapter --name myframework
 Edit the generated `run_mcp.ts` file:
 
 ```typescript
-import { createLangGraphAdapter } from 'automcp-ts/lib/adapters/langgraph.js';
+import { createLangGraphAdapter } from 'automcp-ts';
 import { z } from 'zod';
 import { MyLangGraphAgent } from './my-agent.js';
 
@@ -111,26 +111,20 @@ echo this header so clients can confirm the negotiated protocol version.
 
 ## Adapter API Reference
 
-### Common Interfaces
+### Schema Support
 
-All adapters share these common TypeScript interfaces:
+Adapters accept input definitions in a few different forms so you can keep using
+whichever style is most convenient:
 
-```typescript
-interface BaseModel {
-  [key: string]: any;
-  model_dump?(): Record<string, any>;
-}
-
-interface ModelClass {
-  new (data: any): BaseModel;
-  model_fields?: Record<string, FieldInfo>;
-}
-```
+- A `z.object({...})` instance (recommended)
+- A plain record of Zod field definitions such as `InputSchema.shape`
+- A class that exposes `model_fields`/`model_dump()` for compatibility with
+  Pydantic-style models
 
 ### CrewAI Adapter
 
 ```typescript
-import { createCrewAIAdapter } from 'automcp-ts/lib/adapters/crewai.js';
+import { createCrewAIAdapter } from 'automcp-ts';
 
 const adapter = createCrewAIAdapter(
   crewInstance,      // Your CrewAI agent
@@ -143,7 +137,7 @@ const adapter = createCrewAIAdapter(
 ### LangGraph Adapter
 
 ```typescript
-import { createLangGraphAdapter } from 'automcp-ts/lib/adapters/langgraph.js';
+import { createLangGraphAdapter } from 'automcp-ts';
 
 const adapter = createLangGraphAdapter(
   graphAgent,        // Your LangGraph agent
@@ -156,7 +150,7 @@ const adapter = createLangGraphAdapter(
 ### OpenAI Adapter
 
 ```typescript
-import { createOpenAIAdapter } from 'automcp-ts/lib/adapters/openai.js';
+import { createOpenAIAdapter } from 'automcp-ts';
 
 const adapter = createOpenAIAdapter(
   openaiAgent,       // Your OpenAI agent
@@ -170,7 +164,7 @@ const adapter = createOpenAIAdapter(
 ### Pydantic Adapter
 
 ```typescript
-import { createPydanticAdapter } from 'automcp-ts/lib/adapters/pydantic.js';
+import { createPydanticAdapter } from 'automcp-ts';
 
 const adapter = createPydanticAdapter(
   pydanticAgent,     // Your Pydantic agent
@@ -183,7 +177,7 @@ const adapter = createPydanticAdapter(
 ### LlamaIndex Adapter
 
 ```typescript
-import { createLlamaIndexAdapter } from 'automcp-ts/lib/adapters/llamaindex.js';
+import { createLlamaIndexAdapter } from 'automcp-ts';
 
 const adapter = createLlamaIndexAdapter(
   llamaAgent,        // Your LlamaIndex agent
@@ -197,7 +191,7 @@ const adapter = createLlamaIndexAdapter(
 ### MCP Agent Adapter
 
 ```typescript
-import { createMcpAgentAdapter } from 'automcp-ts/lib/adapters/mcpAgent.js';
+import { createMcpAgentAdapter } from 'automcp-ts';
 
 const adapter = createMcpAgentAdapter(
   agentInstance,     // Agent instance
@@ -217,7 +211,7 @@ const adapter = createMcpAgentAdapter(
 The `ensureSerializable` utility converts complex objects to JSON-safe formats:
 
 ```typescript
-import { ensureSerializable } from 'automcp-ts/lib/adapters/utils.js';
+import { ensureSerializable } from 'automcp-ts';
 
 const safeData = ensureSerializable(complexObject);
 ```
@@ -227,7 +221,7 @@ const safeData = ensureSerializable(complexObject);
 Create Pydantic-like models in TypeScript:
 
 ```typescript
-import { createModel } from 'automcp-ts/lib/adapters/pydantic.js';
+import { createModel } from 'automcp-ts';
 
 const MyModel = createModel({
   name: { annotation: String, required: true },
@@ -250,7 +244,7 @@ Framework configurations are stored in YAML files:
 frameworks:
   langgraph:
     adapter_import: createLangGraphAdapter
-    adapter_module_path: automcp-ts/lib/adapters/langgraph.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourLangGraphAgent } from './your-module.js';"
     adapter_definition: |
       const mcpLanggraphAgent = createLangGraphAdapter(
@@ -299,7 +293,7 @@ const result = await adapter({ query: 'Hello' });
 Full TypeScript support with generic types:
 
 ```typescript
-import { createTypedLangGraphAdapter } from 'automcp-ts/lib/adapters/langgraph.js';
+import { createTypedLangGraphAdapter } from 'automcp-ts';
 
 interface MyInput {
   query: string;
@@ -342,7 +336,7 @@ adapter = create_langgraph_adapter(agent, "name", "desc", InputSchema)
 
 **TypeScript:**
 ```typescript
-import { createLangGraphAdapter } from 'automcp-ts/lib/adapters/langgraph.js';
+import { createLangGraphAdapter } from 'automcp-ts';
 import { z } from 'zod';
 
 const InputSchema = z.object({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -486,7 +486,7 @@ const generateAdapterCommand = (frameworkName: string): Effect.Effect<void, CliE
     const fileName = `${safeName}.adapter.ts`;
     const filePath = join(currentDir, fileName);
     const content = `import { z } from 'zod';
-import { BaseAdapter, AdapterConfig, ToolResult } from 'automcp-ts/lib/adapters/base.js';
+import { BaseAdapter, AdapterConfig, ToolResult } from 'automcp-ts';
 
 class ${pascal}Adapter<T extends Record<string, z.ZodTypeAny>> extends BaseAdapter<T> {
   protected async executeAgent(inputs: z.infer<z.ZodObject<T>>): Promise<any> {

--- a/src/cli_templates/framework_config.yaml
+++ b/src/cli_templates/framework_config.yaml
@@ -1,7 +1,7 @@
 frameworks:
   crewai:
     adapter_import: createCrewAIAdapter
-    adapter_module_path: automcp-ts/lib/adapters/crewai.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourCrewAgent } from './your-module.js';"
     adapter_definition: |
       const mcpCrewai = createCrewAIAdapter(
@@ -14,13 +14,13 @@ frameworks:
 
   mcp_agent:
     adapter_import: createMcpAgentAdapter
-    adapter_module_path: automcp-ts/lib/adapters/mcpAgent.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { yourAgentClass, yourLlm, yourApp, yourAppInitializeFn } from './your-module.js';"
     adapter_definition: |
       const mcpAgent = createMcpAgentAdapter(
         instanceOfYourAgentClass,
         yourLlm, // MCP agent LLM eg OpenAIAugmentedLLM
-        yourApp, // MCP agent app 
+        yourApp, // MCP agent app
         yourAppInitializeFn, // MCP agent app initialize function
         name,
         description,
@@ -30,7 +30,7 @@ frameworks:
 
   langgraph:
     adapter_import: createLangGraphAdapter
-    adapter_module_path: automcp-ts/lib/adapters/langgraph.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourLangGraphAgent } from './your-module.js';"
     adapter_definition: |
       const mcpLanggraphAgent = createLangGraphAdapter(
@@ -43,7 +43,7 @@ frameworks:
 
   pydantic:
     adapter_import: createPydanticAdapter
-    adapter_module_path: automcp-ts/lib/adapters/pydantic.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourPydanticAgent } from './your-module.js';"
     adapter_definition: |
       const mcpPydanticAgent = createPydanticAdapter(
@@ -53,10 +53,10 @@ frameworks:
         InputSchema
       );
     adapter_variable_name: mcpPydanticAgent
-  
+
   llamaindex:
     adapter_import: createLlamaIndexAdapter
-    adapter_module_path: automcp-ts/lib/adapters/llamaindex.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourLlamaIndexAgent } from './your-module.js';"
     adapter_definition: |
       const mcpLlamaindexAgent = createLlamaIndexAdapter(
@@ -69,7 +69,7 @@ frameworks:
 
   openai:
     adapter_import: createOpenAIAdapter
-    adapter_module_path: automcp-ts/lib/adapters/openai.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourOpenAIAgent } from './your-module.js';"
     adapter_definition: |
       const mcpOpenaiAgent = createOpenAIAdapter(
@@ -78,4 +78,4 @@ frameworks:
         description,
         InputSchema
       );
-    adapter_variable_name: mcpOpenaiAgent 
+    adapter_variable_name: mcpOpenaiAgent

--- a/templates/framework_config.yaml
+++ b/templates/framework_config.yaml
@@ -1,7 +1,7 @@
 frameworks:
   crewai:
     adapter_import: createCrewAIAdapter
-    adapter_module_path: automcp-ts/lib/adapters/crewai.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourCrewAIAgent } from './your-agent.js';"
     adapter_definition: |
       const mcpCrewAIAgent = createCrewAIAdapter(
@@ -13,7 +13,7 @@ frameworks:
 
   langgraph:
     adapter_import: createLangGraphAdapter
-    adapter_module_path: automcp-ts/lib/adapters/langgraph.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourLangGraphAgent } from './your-agent.js';"
     adapter_definition: |
       const mcpLangGraphAgent = createLangGraphAdapter(
@@ -25,7 +25,7 @@ frameworks:
 
   llamaindex:
     adapter_import: createLlamaIndexAdapter
-    adapter_module_path: automcp-ts/lib/adapters/llamaindex.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourLlamaIndexAgent } from './your-agent.js';"
     adapter_definition: |
       const mcpLlamaIndexAgent = createLlamaIndexAdapter(
@@ -37,7 +37,7 @@ frameworks:
 
   openai:
     adapter_import: createOpenAIAdapter
-    adapter_module_path: automcp-ts/lib/adapters/openai.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourOpenAIAgent } from './your-agent.js';"
     adapter_definition: |
       const mcpOpenAIAgent = createOpenAIAdapter(
@@ -49,7 +49,7 @@ frameworks:
 
   pydantic:
     adapter_import: createPydanticAdapter
-    adapter_module_path: automcp-ts/lib/adapters/pydantic.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourPydanticAgent } from './your-agent.js';"
     adapter_definition: |
       const mcpPydanticAgent = createPydanticAdapter(
@@ -59,9 +59,9 @@ frameworks:
         InputSchema
       );
 
-  mcp-agent:
+  mcp_agent:
     adapter_import: createMcpAgentAdapter
-    adapter_module_path: automcp-ts/lib/adapters/mcpAgent.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourMcpAgent, llm, app, initializeFn } from './your-agent.js';"
     adapter_definition: |
       const mcpAgentTool = createMcpAgentAdapter(
@@ -76,12 +76,12 @@ frameworks:
 
   express:
     adapter_import: createExpressAdapter
-    adapter_module_path: automcp-ts/lib/adapters/express.js
+    adapter_module_path: automcp-ts
     import_comment: "// import { YourExpressAgent } from './your-agent.js';"
     adapter_definition: |
       const mcpExpressAgent = createExpressAdapter({
         agentInstance: new YourExpressAgent(),
         name: name,
         description: description,
-        inputSchema: InputSchema
+        inputSchema: InputSchema.shape
       });

--- a/templates/run_mcp.ts.template
+++ b/templates/run_mcp.ts.template
@@ -43,9 +43,22 @@ server.tool(
 
 // Server entrypoints
 async function serveStdio() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.log('MCP Server running on stdio');
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+
+  try {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
 }
 
 async function serveSSE() {


### PR DESCRIPTION
## Summary
- add flexible schema utilities and update all framework adapters to work with zod objects, schema records, or model classes
- update CLI templates, README examples, and generator scaffolding to import from the package root
- suppress stdio logging in the run_mcp template and ensure SSE responses echo the negotiated protocol version

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce8a46f70483258bb6e0cf4949f328