### PR TITLE
Refactor base adapter to Effect runtime

### DIFF
--- a/src/adapters/errors.ts
+++ b/src/adapters/errors.ts
@@ -1,0 +1,25 @@
+import { Data } from 'effect';
+
+/** Error raised when input validation fails. */
+export class ValidationError extends Data.TaggedError('ValidationError')<{
+  readonly message: string;
+  readonly issues?: readonly string[];
+  readonly cause?: unknown;
+}> {}
+
+/** Error raised when the underlying agent execution fails. */
+export class ExecutionError extends Data.TaggedError('ExecutionError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+/** Error raised when the agent result cannot be serialized safely. */
+export class SerializationError extends Data.TaggedError('SerializationError')<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export type ToolExecutionError =
+  | ValidationError
+  | ExecutionError
+  | SerializationError;


### PR DESCRIPTION
## Summary
- add typed error classes for adapters using Effect Data.TaggedError
- rewrite BaseAdapter#createToolFunction to orchestrate validation, execution, and serialization with Effect
- map typed failures back to ToolResult errors for existing promise-based consumers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce8b2300f08325b67cfeaf4597d9c7